### PR TITLE
Add load tests

### DIFF
--- a/advancedtest.js
+++ b/advancedtest.js
@@ -20,8 +20,48 @@ let scenarios = {
     vus: 40,
     duration: '1m',
     exec: 'getCrocodilesAndCrocodileByIdTest'
+  },
+  heavy_load_test_short: {
+    executor: 'constant-vus',
+    vus: 40,
+    duration: '30s',
+    exec: 'getCrocodilesAndCrocodileByIdTest'
+  },
+  constant_request_rate: {
+    executor: 'constant-arrival-rate',
+    rate: 1000,
+    timeUnit: '1s', // 1000 iterations per second, i.e. 1000 RPS
+    duration: '30s',
+    preAllocatedVUs: 100, // how large the initial pool of VUs would be
+    maxVUs: 400, // if the preAllocatedVUs are not enough, we can initialize more
+    exec: 'getCrocodilesAndCrocodileByIdTest'
+  },
+  ramping_request_rate:{
+    executor: 'ramping-arrival-rate',
+    startRate: 10,
+    timeunit: '1s',
+    preAllocatedVUs: 50,
+    maxVUs: 500,
+    stages: [
+      {duration: '30s', target: 100}, // Start 10 iterations per `timeUnit`, ramp up to 100 rps in 30s.
+      {duration: '1m', target: 500}, //Continue starting 500 iterations per `timeUnit` for the following minute.
+      {duration: '30s', target: 0}, // Linearly ramp-down to 0 iterations per `timeUnit` over the last 30 seconds.
+    ],
+    exec: 'getCrocodilesAndCrocodileByIdTest' ,
+  },
+  ramping_request_rate_cloud:{
+    executor: 'ramping-arrival-rate',
+    startRate: 10,
+    timeunit: '1s',
+    preAllocatedVUs: 50,
+    maxVUs: 100,
+    stages: [
+      {duration: '30s', target: 50}, // Start 10 iterations per `timeUnit`, ramp up to 100 rps in 30s.
+      {duration: '1m', target: 100}, //Continue starting 500 iterations per `timeUnit` for the following minute.
+      {duration: '30s', target: 30}, // Linearly ramp-down to 30 iterations per `timeUnit` over the last 30 seconds.
+    ],
+    exec: 'getCrocodilesAndCrocodileByIdTest' ,
   }
-
 };
 
 export let options = {
@@ -64,5 +104,6 @@ export function getCrocodilesAndCrocodileByIdTest(){
   
   let res2 = http.get(`https://test-api.k6.io/public/crocodiles/${randomId.toString()}`);
   check(res2, { "status is 200": (res2) => res2.status === 200 });
+  
   
 }


### PR DESCRIPTION
1. Combined the two test functions into one, no longer a distinction between getCrocodile and getCrocodileById. The two requests are made in one test now.


2. Added response.timings object to print specific response time of each of the two get requests.


3. Added different load-test scenarios, decided on separating the previously combined  getCrocodile and getCrocodileById test function into a dedicated **_smoke-test_** test function and **_non-smoke-test_** test function. Because the smoke test has less requests and makes the console.log messages not flood the console, and the console log messages are needed to check the test logic is working. With the correct json being fetched and a random crocodile ID being selected.


4. Added 7 load tests:

- **Smoke test:**
![image](https://github.com/user-attachments/assets/0c5849fc-4fd8-46e6-9308-234c6103ea23)

- **Steady load test:**
![image](https://github.com/user-attachments/assets/514982a3-ac48-4807-9a19-d728282b8c77)

- **Heavy load test:**
![image](https://github.com/user-attachments/assets/78c771fa-b9c5-485e-8f6c-5a7da84abf50)

- **Constant request rate test:**
![image](https://github.com/user-attachments/assets/d615bceb-4df3-42b4-a219-3b37a33b09e4)

- **Ramping request rate test:**
![image](https://github.com/user-attachments/assets/fcf783bf-e208-4cb2-ab5d-c20d56f1a63c)

- **(and Ramping request rate cloud, same test as previous but max VUs 100 to fit cloud allowance)**
![image](https://github.com/user-attachments/assets/92683c1c-ba5a-46c8-80bb-8d292b2a37c2)

- **Heavy load test short:**
_(shorter duration test of the heavy load test, no test data available)._


    

