### PR TITLE
Measure each response time

### DIFF
--- a/advancedtest.js
+++ b/advancedtest.js
@@ -121,5 +121,8 @@ export function getCrocodilesAndCrocodileByIdTest(){
  
   getCrocodilesResponseTime.add(res1.timings.duration)
   getCrocodilesByIdResponseTime.add(res2.timings.duration)
+
+  check(res1, { "res1 status is 500": (res1) => res1.status === 500 });
+  check(res2, { "res2 status is 500": (res2) => res2.status === 500 });
   
 }


### PR DESCRIPTION
1. Added threshold checks for each of the two http get responses, using res.timings.duration object to check how many iterations' responses are under 500ms and 600ms.
2. Added k6 trend objects to add the summary results of average response times for both getCrocodiles and getCrocodilesById, individually.
3. Changed heavy_load_test_short scenario.
4. Added checks for 500 response error.

![image](https://github.com/user-attachments/assets/6db0607c-a474-4263-996b-36344df4574d)
